### PR TITLE
FIX KEY CONSTRAINTS OF ACCOUNT AND TEMPLATE TABLES

### DIFF
--- a/resources/memedatabase.sql
+++ b/resources/memedatabase.sql
@@ -1,57 +1,69 @@
+DROP DATABASE IF EXISTS `memes`;
 CREATE DATABASE IF NOT EXISTS `memes`;
 USE `memes`;
 
+
+DROP TABLE IF EXISTS `account`;
 CREATE TABLE `account` (
-       `account_name` varchar(25) NOT NULL,
-       `account_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-       `email` varchar(32) NOT NULL,
-       `password` varchar(32) NOT NULL,
-       PRIMARY KEY (`account_id`)
+    `account_name`      VARCHAR(25) NOT NULL,
+    `account_id`        SMALLINT(5) UNSIGNED NOT NULL, -- can't be auto incremented because it's part of a composite key
+    `email`             VARCHAR(32) NOT NULL,
+    `password`          VARCHAR(32) NOT NULL,
+    PRIMARY KEY (`account_name`, `account_id`)
 );
 
+DROP TABLE IF EXISTS `meme`;
 CREATE TABLE `meme` (
-       `meme_title` varchar(32) NOT NULL,
-       `meme_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
-       `category` varchar(10),
-       `visibility` BOOLEAN,
-       PRIMARY KEY (`meme_id`)
+    `meme_title`        VARCHAR(32) NOT NULL,
+    `meme_id`           SMALLINT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `category`          VARCHAR(10),
+    `visibility`        BOOLEAN NOT NULL,
+    PRIMARY KEY (`meme_id`)
 );
 
+DROP TABLE IF EXISTS `creates`;
 CREATE TABLE `creates` (
-       `account_name` varchar(25) NOT NULL,
-       `account_id` smallint(5) unsigned NOT NULL,
-       `meme_id` smallint(5) unsigned NOT NULL,
-       `last_update` DATETIME,
-       `creation_date` DATETIME,
-       PRIMARY KEY (`account_name`, `account_id`, `meme_id`),
-       FOREIGN KEY (`account_id`) REFERENCES `account` (`account_id`),
-       FOREIGN KEY (`meme_id`) REFERENCES `meme` (`meme_id`)
+    `account_name`      VARCHAR(25) NOT NULL,
+    `account_id`        SMALLINT(5) UNSIGNED NOT NULL,
+    `meme_id`           SMALLINT(5) UNSIGNED NOT NULL,
+    `last_update`       DATETIME,
+    `creation_date`     DATETIME,
+    PRIMARY KEY (`account_name`, `account_id`, `meme_id`),
+    FOREIGN KEY (`account_name`, `account_id`) REFERENCES `account` (`account_name`, `account_id`),
+    FOREIGN KEY (`meme_id`) REFERENCES `meme` (`meme_id`)
 );
 
+DROP TABLE IF EXISTS `picture`;
 CREATE TABLE `picture` (
-       `picture_title` varchar(25) NOT NULL PRIMARY KEY
+    `picture_title`     VARCHAR(25) NOT NULL PRIMARY KEY,
+    `uri`               VARCHAR(255) NOT NULL
 );
 
+DROP TABLE IF EXISTS `template`;
 CREATE TABLE `template` (
-       `text_box` varchar(32) NOT NULL PRIMARY KEY
+    `template_id`       SMALLINT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `text_box`          VARCHAR(32),
+    PRIMARY KEY (`template_id`)
 );
 
+DROP TABLE IF EXISTS `contains`;
 CREATE TABLE `contains` (
-       `meme_id` smallint(5) unsigned NOT NULL,
-       `picture_title` varchar(25) NOT NULL,
-       `text_box` varchar(32) NOT NULL,
-       PRIMARY KEY (`meme_id`, `picture_title`,  `text_box`),
-       FOREIGN KEY (`meme_id`) REFERENCES `meme` (`meme_id`),
-       FOREIGN KEY (`picture_title`) REFERENCES `picture` (`picture_title`),
-       FOREIGN KEY (`text_box`) REFERENCES `template` (`text_box`)
+    `meme_id`           SMALLINT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `picture_title`     VARCHAR(25) NOT NULL,
+    `template_id`       SMALLINT(32) UNSIGNED NOT NULL,
+    PRIMARY KEY (`meme_id`, `picture_title`,  `template_id`),
+    FOREIGN KEY (`meme_id`)  REFERENCES `meme` (`meme_id`),
+    FOREIGN KEY (`picture_title`) REFERENCES `picture` (`picture_title`),
+    FOREIGN KEY (`template_id`) REFERENCES `template` (`template_id`)
 );
 
+DROP TABLE IF EXISTS `viewed`;
 CREATE TABLE `viewed` (
-       `meme_id` smallint(5) unsigned NOT NULL,
-       `account_name` varchar(25) NOT NULL,
-       `account_id` smallint(5) unsigned NOT NULL,
-       `favorite` BOOLEAN NOT NULL,
-       PRIMARY KEY (`meme_id`, `account_id`),
-       FOREIGN KEY (`meme_id`) REFERENCES `meme` (`meme_id`),
-       FOREIGN KEY (`account_id`) REFERENCES `account` (`account_id`)
+    `meme_id`           SMALLINT(5) UNSIGNED NOT NULL,
+    `account_name`      VARCHAR(25) NOT NULL,
+    `account_id`        SMALLINT(5) UNSIGNED NOT NULL,
+    `favorite`          BOOLEAN NOT NULL,
+    PRIMARY KEY (`meme_id`, `account_id`, `account_name`),
+    FOREIGN KEY (`meme_id`) REFERENCES `meme` (`meme_id`),
+    FOREIGN KEY (`account_name`, `account_id`) REFERENCES `account` (`account_name`, `account_id`)
 );


### PR DESCRIPTION
Updates these primary keys (and respective foreign keys):
 - PK of account table is now a composite of the name and id.
 - PK of template table is now the template id.

Other misc changes to document formatting, like whitespace and letter
casing.